### PR TITLE
Ensure that we also require the users are created

### DIFF
--- a/lib/puppet/type/groupmembership.rb
+++ b/lib/puppet/type/groupmembership.rb
@@ -5,6 +5,10 @@ Puppet::Type.newtype(:groupmembership) do
     self[:name]
   end
 
+  autorequire(:user) do
+    self[:members]
+  end
+
   newparam :name, :namevar => true
 
   newparam(:exclusive) do


### PR DESCRIPTION
Without this change, user may get created after the membership is
applied to the group.  This means that to arrive at the desired group
membership, it takes two puppet runs.

This work corrects the behavior by requiring that any users being
managed by puppet get created before the membership for the given group
is set.